### PR TITLE
Dev: Dynamic Tile Map Rendering for 2D Game

### DIFF
--- a/client/src/components/Canvas.jsx
+++ b/client/src/components/Canvas.jsx
@@ -1,29 +1,41 @@
+// Canvas.jsx
+
 import React, { useEffect, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { updatePlayerPosition } from '../game/control/player'; 
-import { drawGameWorld } from '../game/scenes/world'; 
+import { drawGameWorld, drawTile } from '../game/scenes/world'; // Import the new drawTile function
 import { drawPlayer, playerImgUrl } from '../game/scenes/player'; 
-import { animate } from '../game/animations/animate'; // Import the animate function from the external file
-
+import { animate } from '../game/animations/animate';
+import { TILE_TYPES } from '../game/items/tiles/types'; // Import the TILE_TYPES object
 
 const Canvas = ({ draw, height, width, spriteSize = 4, spriteMiddle = 2 }) => {
   const canvasRef = useRef();
   const playerImageRef = useRef(new Image());
   playerImageRef.current.src = playerImgUrl;
-  const playerPosition = useMemo(() => ({ x: width / 2, y: height / 2 }), [height, width]); // Initial player position
+  const playerPosition = useMemo(() => ({ x: width / 2, y: height / 2 }), [height, width]);
+
+  // Tile map data
+  const initialTileMap = [
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WOOD',  'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],  
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+    ['GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'WATER', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS', 'GRASS'],
+  ];
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
-
-    const cleanup = animate(ctx, drawGameWorld, updatePlayerPosition, drawPlayer, width, height, playerPosition, playerImageRef, spriteSize);
-
+    const cleanup = animate(ctx, () => drawGameWorld(ctx, width, height, initialTileMap), updatePlayerPosition, drawPlayer, width, height, playerPosition, playerImageRef, spriteSize);
     return () => {
       cleanup();
     };
-  }, [draw, height, width, playerPosition, playerImageRef, spriteSize]);
-
-  // ...
+  }, [draw, height, width, playerPosition, playerImageRef, spriteSize, initialTileMap]);
 
   return <canvas ref={canvasRef} height={height} width={width} />;
 };

--- a/client/src/game/items/tiles/types.js
+++ b/client/src/game/items/tiles/types.js
@@ -1,0 +1,34 @@
+// tileTypes.js (create a new file to define TILE_TYPES)
+
+export const TILE_TYPES = {
+  EMPTY: {
+    id: 0,
+    name: 'Empty',
+    color:'white'
+  },
+  GRASS: {
+    id: 1,
+    name: 'Grass',
+    color: 'green'
+  },
+  WATER: {
+    id: 2,
+    name: 'Water',
+    color: 'blue'
+  },
+  ROCK: {
+    id: 3,
+    name: 'Rock',
+    color: 'grey'
+  },
+  SAND: {
+    id: 4,
+    name: 'Sand',
+    color: 'yellow'
+  },
+  WOOD: {
+    id: 5,
+    name: 'Wooden',
+    color: 'brown'
+  },
+};

--- a/client/src/game/scenes/world.js
+++ b/client/src/game/scenes/world.js
@@ -1,6 +1,25 @@
-export const drawGameWorld = (ctx, width, height) => {
-    const gameWorldRef = new Image();
-    gameWorldRef.src = 'https://i.imgur.com/rkxlut8.png';
-    ctx.drawImage(gameWorldRef, 0, 0, width, height);
-  };
-  
+// world.js
+
+import { TILE_TYPES } from '../items/tiles/types';
+
+// Function to draw a tile
+export const drawTile = (ctx, x, y, type) => {
+  ctx.fillStyle = TILE_TYPES[type]?.color || 'gray'; // Set the tile color based on its type
+  ctx.fillRect(x, y, 64, 64); // Assuming each tile is 64x64 pixels
+};
+
+// Function to draw the game world with tiles
+export const drawGameWorld = (ctx, width, height, tileMap) => {
+  // Clear the canvas
+  ctx.clearRect(0, 0, width, height);
+
+  // Loop through the tileMap and draw tiles
+  for (let row = 0; row < tileMap.length; row++) {
+    for (let col = 0; col < tileMap[row].length; col++) {
+      const tileType = tileMap[row][col];
+      const x = col * 64; // Assuming each tile is 64x64 pixels
+      const y = row * 64; // Assuming each tile is 64x64 pixels
+      drawTile(ctx, x, y, tileType);
+    }
+  }
+};


### PR DESCRIPTION
Example map with Grass, Water and Wood

![image](https://github.com/Underewarrr/pokemon-javascript-react-game/assets/74227915/5a3f5996-33cd-4e9c-8984-6dbf43af5073)


We implemented dynamic tile map rendering for our 2D game. We introduced a `TILE_TYPES` object that defines different types of tiles along with their corresponding colors. 
The `drawTile` function was updated to use this object to render tiles on the canvas based on the provided tile map data.

To showcase this feature, we created a new tile map representing a grass area with a river. The map is loaded and rendered using the Canvas component, which also includes the player and their movement logic.

This dynamic tile map rendering enables us to create diverse and customizable game worlds, making our 2D game more engaging and immersive. 
The commit lays the foundation for further expansion of the game world with different tile types, adding depth and complexity to the gameplay experience.

The addition of dynamic map loading and rendering will greatly enhance the gameplay and level design possibilities of our 2D game. This marks an exciting milestone in the development of our project and sets the stage for further advancements in the game's environment and mechanics.